### PR TITLE
Fix conf.d directory not being removed

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -58,6 +58,7 @@ class clickhouse::client(
     } else {
         file { '/etc/clickhouse-client/conf.d':
             ensure => 'absent',
+            force  => true,
         }
 
         file { $config_d_dir:


### PR DESCRIPTION
Puppet would refuse to remove the conf.d directory because it's not a plain file.  Add `force` so it'll get removed.